### PR TITLE
Fix upstart config

### DIFF
--- a/avahi_aliases/etc/init/avahi-aliases.conf
+++ b/avahi_aliases/etc/init/avahi-aliases.conf
@@ -9,14 +9,10 @@ start on (filesystem
 	  and started dbus)
 stop on stopping dbus
 
-expect daemon
 respawn
+exec /usr/local/bin/avahi-alias start
 
-pre-start script
-	exec /usr/local/bin/avahi-alias start
-end script
-
-post-stop script
+pre-stop script
 	exec /usr/local/bin/avahi-alias stop
 end script
 


### PR DESCRIPTION
This PR prevents `start avahi-aliases` from hanging and tracks the appropriate PID.
