### PR TITLE
Fix hang on start/stop on Ubuntu 14.04

### DIFF
--- a/avahi_aliases/etc/init/avahi-aliases.conf
+++ b/avahi_aliases/etc/init/avahi-aliases.conf
@@ -9,15 +9,8 @@ start on (filesystem
 	  and started dbus)
 stop on stopping dbus
 
-expect daemon
 respawn
 
-pre-start script
-	exec /usr/local/bin/avahi-alias start
+script
+   exec /usr/local/bin/avahi-alias start
 end script
-
-post-stop script
-	exec /usr/local/bin/avahi-alias stop
-end script
-
-


### PR DESCRIPTION
The init script hangs on Ubuntu 14.04. I've tried various combination of expect daemon or fork. This commit is the one that finally worked. I've not tested against previous releases.